### PR TITLE
Fix: find the certification file on ./certs

### DIFF
--- a/aws-iot-events-for-beginners/main.py
+++ b/aws-iot-events-for-beginners/main.py
@@ -119,7 +119,7 @@ def find_certs_file():
                 file_list[0] = certs_dir + "/" + file
             elif "private" in file:
                 file_list[1] = certs_dir + "/" + file
-            elif "certificate" in file:
+            elif "cert" in file:
                 file_list[2] = certs_dir + "/" + file
 
     return file_list


### PR DESCRIPTION
*Issue #, if available:*

#ハンズオン中の問題どころ

```
# フォルダの作成と移動
mkdir -p ~/environment/dummy_client/certs/
cd ~/environment/dummy_client/

# ダウンロード（実際は改行なしで1行で入力）
wget https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/aws-iot-core-workshop/dummy_client/device_main.py -O device_main.py
```

https://aws-iot-core-for-beginners.workshop.aws/phase2/step1.html

*Description of changes:

certificationの名前が{device-name}.cert.pemなので今

```
#device_main.py 140 line
elif "certificate" in file:
                file_list[2] = certs_dir + "/" + file
```

<img width="395" alt="스크린샷 2020-12-28 오전 6 45 50" src="https://user-images.githubusercontent.com/50096419/103180346-53bd9000-48d8-11eb-8376-cc15cee795de.png">

の状況になりました。

それで下のように変えたらできましたのでPRしました。

```
#device_main.py 140 line
 elif "cert" in file:
                file_list[2] = certs_dir + "/" + file
```

<img width="396" alt="스크린샷 2020-12-28 오전 6 50 44" src="https://user-images.githubusercontent.com/50096419/103180437-29b89d80-48d9-11eb-964c-b2e1d04bafd5.png">




```
https://awsj-iot-handson.s3-ap-northeast-1.amazonaws.com/aws-iot-core-workshop/dummy_client/device_main.py
```

が同じファイルだど思います。このPRが大丈夫だと思ったら、後からハンスオンをする方のためにsyncしてくれば嬉しいです！





By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
